### PR TITLE
Add phpstan command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Run tests on the `web/modules/custom` directory:
 - `ddev nightwatch` Run Nightwatch tests, requires [DDEV Selenium Standalone Chrome](https://github.com/ddev/ddev-selenium-standalone-chrome).
 - `ddev phpcs` Run [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 - `ddev phpcbf` Fix phpcs findings.
-- `ddev phpstan`. Run phpstan on the web/modules/custom directory.
+- `ddev phpstan`. Run [phpstan](https://phpstan.org) on the web/modules/custom directory.
 - `ddev eslint` Run [ESLint](https://github.com/eslint/eslint) on JavaScript files.
 - `ddev stylelint` Run [Stylelint](https://github.com/stylelint/stylelint) on CSS files.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Run tests on the `web/modules/custom` directory:
 - `ddev nightwatch` Run Nightwatch tests, requires [DDEV Selenium Standalone Chrome](https://github.com/ddev/ddev-selenium-standalone-chrome).
 - `ddev phpcs` Run [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 - `ddev phpcbf` Fix phpcs findings.
+- `ddev phpstan`. Run phpstan on the web/modules/custom directory.
 - `ddev eslint` Run [ESLint](https://github.com/eslint/eslint) on JavaScript files.
 - `ddev stylelint` Run [Stylelint](https://github.com/stylelint/stylelint) on CSS files.
 

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -13,6 +13,8 @@ if ! command -v phpstan >/dev/null; then
   exit 1
 fi
 test -e phpstan.neon || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpstan.neon
+# Add an empty baseline file to ensure it exists.
+test -e phpstan-baseline.neon || touch phpstan-baseline.neon
 export COMPOSER=composer.contrib.json
 .ddev/commands/web/expand-composer-json "$DDEV_PROJECT_NAME"
 phpstan analyse $DDEV_DOCROOT/modules/custom "$@"

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -9,7 +9,7 @@
 ## ExecRaw: true
 
 if ! command -v phpstan >/dev/null; then
-  echo "phpstan is not available. You may need to 'ddev composer install'"
+  echo "phpstan is not available. You may need to 'ddev poser'"
   exit 1
 fi
 test -e phpstan.neon || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpstan.neon

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -12,6 +12,7 @@ if ! command -v phpstan >/dev/null; then
   echo "phpstan is not available. You may need to 'ddev composer install'"
   exit 1
 fi
+test -e phpstan.neon || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpstan.neon
 export COMPOSER=composer.contrib.json
 .ddev/commands/web/expand-composer-json "$DDEV_PROJECT_NAME"
 phpstan analyse $DDEV_DOCROOT/modules/custom "$@"

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -5,7 +5,7 @@
 ## Description: Run phpstan inside the web container
 ## Usage: phpstan [flags] [args]
 ## Example: "ddev phpstan" or "ddev phpstan -n"
-## ProjectTypes: drupal8,drupal9,drupal10
+## ProjectTypes: drupal,drupal8,drupal9,drupal10
 ## ExecRaw: true
 
 if ! command -v phpstan >/dev/null; then

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -16,3 +16,4 @@ test -e phpstan.neon || curl -OL https://git.drupalcode.org/project/gitlab_templ
 export COMPOSER=composer.contrib.json
 .ddev/commands/web/expand-composer-json "$DDEV_PROJECT_NAME"
 phpstan analyse $DDEV_DOCROOT/modules/custom "$@"
+rm composer.contrib.json composer.contrib.lock

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -15,7 +15,4 @@ fi
 test -e phpstan.neon || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpstan.neon
 # Add an empty baseline file to ensure it exists.
 test -e phpstan-baseline.neon || touch phpstan-baseline.neon
-export COMPOSER=composer.contrib.json
-.ddev/commands/web/expand-composer-json "$DDEV_PROJECT_NAME"
 phpstan analyse $DDEV_DOCROOT/modules/custom "$@"
-rm composer.contrib.json

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -12,4 +12,6 @@ if ! command -v phpstan >/dev/null; then
   echo "phpstan is not available. You may need to 'ddev composer install'"
   exit 1
 fi
+export COMPOSER=composer.contrib.json
+.ddev/commands/web/expand-composer-json "$DDEV_PROJECT_NAME"
 phpstan analyse $DDEV_DOCROOT/modules/custom "$@"

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Run phpstan inside the web container
+## Usage: phpstan [flags] [args]
+## Example: "ddev phpstan" or "ddev phpstan -n"
+## ProjectTypes: drupal8,drupal9,drupal10
+## ExecRaw: true
+
+if ! command -v phpstan >/dev/null; then
+  echo "phpstan is not available. You may need to 'ddev composer install'"
+  exit 1
+fi
+phpstan analyse web/modules/custom "$@"

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -16,4 +16,4 @@ test -e phpstan.neon || curl -OL https://git.drupalcode.org/project/gitlab_templ
 export COMPOSER=composer.contrib.json
 .ddev/commands/web/expand-composer-json "$DDEV_PROJECT_NAME"
 phpstan analyse $DDEV_DOCROOT/modules/custom "$@"
-rm composer.contrib.json composer.contrib.lock
+rm composer.contrib.json

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -12,4 +12,4 @@ if ! command -v phpstan >/dev/null; then
   echo "phpstan is not available. You may need to 'ddev composer install'"
   exit 1
 fi
-phpstan analyse web/modules/custom "$@"
+phpstan analyse $DDEV_DOCROOT/modules/custom "$@"

--- a/commands/web/poser
+++ b/commands/web/poser
@@ -11,5 +11,4 @@ export COMPOSER=composer.contrib.json
 .ddev/commands/web/expand-composer-json "$DDEV_PROJECT_NAME"
 composer install
 rm composer.contrib.json composer.contrib.lock
-yarn --cwd $DDEV_DOCROOT/core install
 touch $DDEV_DOCROOT/core/.env

--- a/install.yaml
+++ b/install.yaml
@@ -5,6 +5,7 @@ project_files:
   - commands/web/nightwatch
   - commands/web/phpcbf
   - commands/web/phpcs
+  - commands/web/phpstan
   - commands/web/phpunit
   - commands/web/poser
   - commands/web/stylelint

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -23,6 +23,7 @@ teardown() {
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR}/${PROJNAME} ($(pwd))" >&3
   ddev get ${DIR}
   ddev config --auto
+  ddev config --corepack-enable
   ddev start
   ddev expand-composer-json
   ddev composer install

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -29,6 +29,7 @@ teardown() {
   ddev symlink-project
   ddev drush st
   ddev phpcs --version
+  ddev phpstan --version
   ls -al web/modules/custom/${PROJNAME}/tests
   ddev phpunit --version
   ddev yarn --cwd web/core install


### PR DESCRIPTION
## The Issue
Adds support for `phpstan` command to more closely mimic [GitLab CI configuration/runs](https://git.drupalcode.org/search?search=phpstan&nav_source=navbar&project_id=96292&group_id=2&search_code=true&repository_ref=1.0.x).

## How This PR Solves The Issue
* Adds the phpstan command.
* Updates README documentation to include command.

## Manual Testing Instructions
1. Run `ddev phpstan`
2. PHPStan should run as expected.

## Automated Testing Overview

N/A

## Related Issue Link(s)

Closes https://github.com/ddev/ddev-drupal-contrib/issues/13

## Release/Deployment Notes

N/A
