### PR TITLE
Add additional steps needed to finish setup on contrib projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Install
 3. cd [contrib module directory]
 4. Configure DDEV for Drupal 10 using `ddev config --project-name=[contrib module] --project-type=drupal10 --docroot=web --create-docroot --php-version=8.1` or select these options when prompted using `ddev config`
 5. Run `ddev get ddev/ddev-drupal-contrib`.
+6. Run `ddev start`.
+7. Run `ddev poser`.
+8. Run `ddev symlink-project`.
 
 Commands
 ============


### PR DESCRIPTION
## The Issue
When following the README Installation instructions for setting up a contrib project, additional setup is required before being able to run the commands provided by this project.

## How This PR Solves The Issue

Explicitly list all steps needed for setup.

## Manual Testing Instructions

Review documentation changes.

## Automated Testing Overview

N/A. Documentation update.

## Related Issue Link(s)
Related: https://github.com/ddev/ddev-drupal-contrib/issues/15

## Release/Deployment Notes

N/A