### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
+# DDEV Drupal Contrib
+
 DDEV integration for developing Drupal contrib projects. As a general philosophy, your contributed module is the center of the universe. The codebase layout (see image below) and commands in this project [match the Gitlab CI approach](https://git.drupalcode.org/project/gitlab_templates) from the Drupal Association.
 
-Install
-===========
+
+## Install
 
 1. If you haven't already, [install Docker and DDEV](https://ddev.readthedocs.io/en/latest/users/install/)
 2. `git clone` your contrib module
 3. cd [contrib module directory]
 4. Configure DDEV for Drupal 10 using `ddev config --project-name=[contrib module] --project-type=drupal10 --docroot=web --create-docroot --php-version=8.1` or select these options when prompted using `ddev config`
-   1. If your module has underscores in its name, replace them with hyphens.
+   - Remove underscores in the project name, or replace with hyphens.
 5. Run `ddev get ddev/ddev-drupal-contrib`
 6. Run `ddev start`
 7. Run `ddev poser`
 8. Run `ddev symlink-project`
 
-Commands
-============
+
+## Commands
 
 This project provides the following DDEV container commands.
 
@@ -23,32 +25,57 @@ This project provides the following DDEV container commands.
   - Runs `composer install` AND `yarn install` so that dependencies are available.
   - Note: it is perfectly acceptable to skip this command and edit the require-dev of composer.json by hand.
 - [ddev symlink-project](https://github.com/ddev/ddev-drupal-contrib/blob/main/commands/web/symlink-project). This symlinks the top level files of your project into web/modules/custom so that Drupal finds your module. This command runs automatically on every `ddev start`. See codebase image below.
-- `ddev phpunit`. Run phpunit tests on the web/modules/custom directory.
-- `ddev nightwatch`. Run nightwatch tests on the web/modules/custom directory.
-- `ddev phpcs`. Run phpcs on the web/modules/custom directory.
-- `ddev phpcbf`. Fix phpcs findings in the web/modules/custom directory.
-- `ddev eslint`. Run eslint on the js files in the web/modules/custom directory.
-- `ddev stylelint`. Run stylelint on the css files in the web/modules/custom directory.
 
-Codebase layout
-==================
+Run tests on the `web/modules/custom` directory:
+
+- `ddev phpunit` Run [PHPUnit](https://github.com/sebastianbergmann/phpunit) tests.
+- `ddev nightwatch` Run Nightwatch tests, requires [DDEV Selenium Standalone Chrome](https://github.com/ddev/ddev-selenium-standalone-chrome).
+- `ddev phpcs` Run [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/tree/master).
+- `ddev phpcbf` Fix phpcs findings.
+- `ddev eslint` Run [ESLint](https://github.com/eslint/eslint) on JavaScript files.
+- `ddev stylelint` Run [Stylelint](https://github.com/stylelint/stylelint) on CSS files.
+
+
+## Codebase layout
 
 ![Folder tree](/assets/folders.png)
 
-Misc
-=======
+
+## Misc
 
 - Optional: [Install Chrome service for FunctionalJavascript and Nightwatch tests](https://github.com/ddev/ddev-selenium-standalone-chrome).
-- Optional. Commit the changes .ddev after this plugin installs. This saves other users from having to install this integration. Rerun the `ddev get` in order to update the commands from this project.
-- This project reads your `project_type` from DDEV and fetches adds the corresponding version of `drupal/core-recommended` to composer.json. if you are doing something non-standard with project_type, don't use `ddev poser` command.
+- Optional. Commit the changes in the `.ddev` folder after this plugin installs. This saves other users from having to install this integration. Rerun the `ddev get` in order to update the commands from this project.
+- This project reads your `project_type` from DDEV and fetches adds the corresponding version of `drupal/core-recommended` to `composer.json`. if you are doing something non-standard with project_type, don't use `ddev poser` command.
 - This project should work for any contrib project, including those that haven't [opted into Gitlab CI](https://www.drupal.org/project/infrastructure/issues/3261803). One advantage of that is that failures in CI are more likely to be reproducible locally when using this integration.
 - If you add/remove a root file or directory, re-symlink root files via EITHER of these methods
   - `ddev restart`
   - `ddev symlink-project`
 - `cweagans/composer-patches:^1` is added by `ddev poser` so feel free to configure any patches that your project needs.
 
-Troubleshooting
-=======
+
+## Example of succesful test
+
+This is what a succesful test looks like, based on [Config Enforce Devel](https://www.drupal.org/project/config_enforce_devel).
+
+```
+user:~/config_enforce_devel$ ddev phpunit
+PHPUnit 9.6.15 by Sebastian Bergmann and contributors.
+
+Default Target Module (Drupal\Tests\config_enforce_devel\Functional\DefaultTargetModule)
+ ✔ Default target module created
+
+Form Alter Implementation Order (Drupal\Tests\config_enforce_devel\Functional\FormAlterImplementationOrder)
+ ✔ Form alter implementation order
+
+Theme Settings Form (Drupal\Tests\config_enforce_devel\Functional\ThemeSettingsForm)
+ ✔ Theme settings form submit
+
+Time: 00:13.453, Memory: 4.00 MB
+
+OK (3 tests, 20 assertions)
+```
+
+## Troubleshooting
 
 "Error: unknown command":
 


### PR DESCRIPTION
## The Issue

I have tried to run a PHPUnit test without success on a few modules (Admin toolbar, Simplenews), some tests pass, others fail. Adding  [DDEV Selenium Standalone Chrome](https://github.com/ddev/ddev-selenium-standalone-chrome) helped resolve some tests, but I still got some Behat errors.

There are a lot of moving parts, and it would be nice to give new users a success from the start, where all tests are passing. We could add an example of a contrib module which fulfills this requirement, such as [Config Enforce Devel](https://www.drupal.org/project/config_enforce_devel). 

Also, it would be nice with a human readable header.

## How This PR Solves The Issue

Add a header, update the test commands, add links, add example of a successful test.
