### PR TITLE
allow local phpunit config

### DIFF
--- a/commands/web/phpunit
+++ b/commands/web/phpunit
@@ -12,4 +12,12 @@ if ! command -v phpunit >/dev/null; then
   echo "phpunit is not available. You may need to 'ddev composer install'"
   exit 1
 fi
-phpunit --printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" --bootstrap $PWD/$DDEV_DOCROOT/core/tests/bootstrap.php --testdox $DDEV_DOCROOT/modules/custom "$@"
+
+# CHECK for local config.
+if [ -f "phpunit.xml" ]; then
+    # Defer to local config
+    phpunit "$@"
+else
+    # Bootstrap Drupal tests and run all custom module tests.
+    phpunit --printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" --bootstrap $PWD/$DDEV_DOCROOT/core/tests/bootstrap.php --testdox $DDEV_DOCROOT/modules/custom "$@"
+fi


### PR DESCRIPTION
This PR improves PHPunit configure-ablity. 
The idea being, if a repository has phpunit config file present, it will default to using it.

## Behavior

When running `ddev phpiunit`

If a `phpunit.xml` (PHPunit config file)  is present, it used it by default.
If a `phpunit.xml` is NOT present, it runs the command as currently set.

## Reasons

This PR allows developers to add and commit phpunit configuration which then can be used by default. These values could be added via CLI, but this become quite verbose if lots of settings are require (I was working on a module in a Gitpod workspace). 
 
While devlopers can take control of the command and make the required adjust, doing so prevents future updates. 