### PR TITLE
Fix broken tests

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -22,7 +22,7 @@ teardown() {
   cd ${TESTDIR}/${PROJNAME}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR}/${PROJNAME} ($(pwd))" >&3
   ddev get ${DIR}
-  ddev config --nodejs-version 18
+  ddev config --nodejs-version 18 --project-type=drupal10
   ddev start
   ddev expand-composer-json
   composer install

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -25,7 +25,7 @@ teardown() {
   ddev config --nodejs-version 18 --project-type=drupal10
   ddev start
   ddev expand-composer-json
-  composer install
+  ddev composer install
   ddev symlink-project
   ddev drush st
   ddev phpcs --version


### PR DESCRIPTION
This PR resolves 2 main issues the bats tests:

- 'expand-composer-json'
- `composer`

## Details

'expand-composer-json' is only discoverable when the correct project-type is set. Valid project types current are "drupal8,drupal9,drupal10" This PR sets project type to "drupal10" as this is currently the default Drupal version.

`composer` is typically run inside the DDEV web container, which this PR  addressed.