### PR TITLE
fix: symlink project with underscores instead of hyphens

### DIFF
--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -12,5 +12,8 @@ export _WEB_ROOT=$DDEV_DOCROOT
 #todo use more dynamic ref.
 cd "$DDEV_COMPOSER_ROOT" || exit
 curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/1.0.x/scripts/symlink_project.php
-php symlink_project.php "$DDEV_SITENAME"
+
+# Symlink name using underscores.
+# @see https://www.drupal.org/docs/develop/creating-modules/naming-and-placing-your-drupal-module
+php symlink_project.php "${DDEV_SITENAME//-/_}"
 rm -f symlink_project.php


### PR DESCRIPTION
This PR fixes an issue with projects that use 'underscores' in their name. 
- underscores are valid in machine names for Drupal modules, 
- underscores are invalid in hostnames.  

This can lead to inconsistency when using a project name as the sym-linked folder name.

## Problem

I have a module named 'apple_banana'.

Drupal rules state machine name as "only lower-case letters, digits, and underscores" (https://www.drupal.org/docs/develop/creating-modules/naming-and-placing-your-drupal-module#s-name-your-module)

Given this module is in a directory called `apple_banana`, I am unable to create a DDEV project in this folder:

```shell
$ ddev config
Creating a new DDEV project config in the current directory 
...
Project name (apple_banana):
apple_banana is not a valid project name. Please enter a project name in your configuration that will allow for a valid hostname. See https://en.wikipedia.org/wiki/Hostname#Syntax for valid hostname requirements
```

If I rename the project folder to `apple-banana`, DDEV creates successfully. (If not provided, DDEV automatically uses the folder name, here `apple-banana`, as site name)

When I run `ddev symlink-project`, the project is linked as `web/modules/custom/apple-banana` (using `$DDEV_SITENAME`). 

This functions, but leads to a problem with local translations, `%project` should resolve to the module machine name 

```
'interface translation project': 'apple_banana'
'interface translation server pattern': 'modules/custom/%project/translations/%language.po'
```

If this was hardcoded with the module name, it would be expecting to find the 'underscored' machine-name version of the module.

@see https://api.drupal.org/api/drupal/core%21modules%21locale%21locale.api.php/group/interface_translation_properties/10
