### PR TITLE
Update script URLs to use the recommended default-ref

### DIFF
--- a/commands/web/expand-composer-json
+++ b/commands/web/expand-composer-json
@@ -13,6 +13,6 @@ export _WEB_ROOT=$DDEV_DOCROOT
 [[ $DDEV_PROJECT_TYPE == "drupal9" ]] && export _TARGET_CORE=^9
 [[ $DDEV_PROJECT_TYPE == "drupal8" ]] && export _TARGET_CORE=^8
 cd "$DDEV_COMPOSER_ROOT" || exit
-curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/1.0.x/scripts/expand_composer_json.php
+curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/expand_composer_json.php
 php expand_composer_json.php "$DDEV_SITENAME"
 rm -f expand_composer_json.php

--- a/commands/web/phpcbf
+++ b/commands/web/phpcbf
@@ -12,5 +12,5 @@ if ! command -v phpcbf >/dev/null; then
   echo "phpcbf is not available. You may need to 'ddev composer install'"
   exit 1
 fi
-test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/1.0.x/scripts/phpcs.xml.dist
+test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/phpcs.xml.dist
 phpcbf -s --report-full --report-summary --report-source web/modules/custom "$@"

--- a/commands/web/phpcs
+++ b/commands/web/phpcs
@@ -12,5 +12,5 @@ if ! command -v phpcs >/dev/null; then
   echo "phpcs is not available. You may need to 'ddev composer install'"
   exit 1
 fi
-test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/1.0.x/scripts/phpcs.xml.dist
+test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/phpcs.xml.dist
 phpcs -s --report-full --report-summary --report-source web/modules/custom "$@"

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -11,7 +11,7 @@
 export _WEB_ROOT=$DDEV_DOCROOT
 #todo use more dynamic ref.
 cd "$DDEV_COMPOSER_ROOT" || exit
-curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/1.0.x/scripts/symlink_project.php
+curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/symlink_project.php
 
 # Symlink name using underscores.
 # @see https://www.drupal.org/docs/develop/creating-modules/naming-and-placing-your-drupal-module


### PR DESCRIPTION
## The Issue

Branch `1.0.x` in Gitlab templates has been deprecated and did not receive commits in 2 months.

## How This PR Solves The Issue

Replace usage of `1.0.x` in URLs with the `default-ref` that is recommended.

## Related Issue Link(s)

https://www.drupal.org/project/gitlab_templates/issues/3404175
