### PR TITLE
Fix ddev-mkdocs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run tests on the `web/modules/custom` directory:
 ## Misc
 
 - Optional: [Install the ddev-selenium-standalone-chrome extension for FunctionalJavascript and Nightwatch tests](https://github.com/ddev/ddev-selenium-standalone-chrome).
-- Optional: [Install the ddev-mkdocs extension for local preview of your docs site](https://github.com/ddev/ddev-mkdocs). Drupal.org's Gitlab CI can [automatically publish your site](https://project.pages.drupalcode.org/gitlab_templates/jobs/pages/).
+- Optional: [Install the ddev-mkdocs extension for local preview of your docs site](https://github.com/nireneko/ddev-mkdocs). Drupal.org's Gitlab CI can [automatically publish your site](https://project.pages.drupalcode.org/gitlab_templates/jobs/pages/).
 - Optional. Commit the changes in the `.ddev` folder after this plugin installs. This saves other users from having to install this integration.
 - This project reads your `project_type` from DDEV and fetches adds the corresponding version of `drupal/core-recommended` to `composer.json`. if you are doing something non-standard with project_type, don't use `ddev poser` command.
 - This project should work for any contrib project, including those that haven't [opted into Gitlab CI](https://www.drupal.org/project/infrastructure/issues/3261803). One advantage of that is that failures in CI are more likely to be reproducible locally when using this integration.


### PR DESCRIPTION
## The Issue

Just followed your discuss in #ddev channel and found the link to ddev-mkdocs added in this project was wrong.