### PR TITLE
Change Drupal core determine in ddev poser command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DDEV integration for developing Drupal contrib projects. As a general philosophy
 1. If you haven't already, [install Docker and DDEV](https://ddev.readthedocs.io/en/latest/users/install/)
 2. `git clone` your contrib module
 3. cd [contrib module directory]
-4. Configure DDEV for Drupal 10 using `ddev config --project-name=[contrib module] --project-type=drupal10 --docroot=web --create-docroot --php-version=8.1` or select these options when prompted using `ddev config`
+4. Configure DDEV for Drupal 10 using `ddev config --project-name=[contrib module] --project-type=drupal10 --docroot=web --php-version=8.1` or select these options when prompted using `ddev config`
    - Remove underscores in the project name, or replace with hyphens.
 5. Run `ddev get ddev/ddev-drupal-contrib`
 6. Run `ddev start`

--- a/commands/web/expand-composer-json
+++ b/commands/web/expand-composer-json
@@ -5,13 +5,14 @@
 ## Description: Add Drupal core and other needed dependencies.
 ## Usage: expand-composer-json [flags] [PROJECT_NAME]
 ## Example: "ddev expand-composer-json ctools"
-## ProjectTypes: drupal8,drupal9,drupal10
+## ProjectTypes: drupal,drupal8,drupal9,drupal10
 ## ExecRaw: true
 
 export _WEB_ROOT=$DDEV_DOCROOT
-[[ $DDEV_PROJECT_TYPE == "drupal10" ]] && export _TARGET_CORE=^10
-[[ $DDEV_PROJECT_TYPE == "drupal9" ]] && export _TARGET_CORE=^9
-[[ $DDEV_PROJECT_TYPE == "drupal8" ]] && export _TARGET_CORE=^8
+[[ $DDEV_PROJECT_TYPE == "drupal" ]] && export DRUPAL_CORE=^10
+[[ $DDEV_PROJECT_TYPE == "drupal10" ]] && export DRUPAL_CORE=^10
+[[ $DDEV_PROJECT_TYPE == "drupal9" ]] && export DRUPAL_CORE=^9
+[[ $DDEV_PROJECT_TYPE == "drupal8" ]] && export DRUPAL_CORE=^8
 cd "$DDEV_COMPOSER_ROOT" || exit
 curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/expand_composer_json.php
 php expand_composer_json.php "$DDEV_SITENAME"


### PR DESCRIPTION
## The Issue

The original issue here. https://github.com/ddev/ddev-drupal-contrib/issues/44

## How This PR Solves The Issue

This changes how the Drupal core version is determined.

## Manual Testing Instructions

This was tested with both DDEV 1.22.7 and DDEV 1.23.1 that it now installs the correct core version and development dependencies.

## Automated Testing Overview

TBD.
