### PR TITLE
Less smart Drupal core version detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ DDEV integration for developing Drupal contrib projects. As a general philosophy
 3. cd [contrib module directory]
 4. Configure DDEV for Drupal 10 using `ddev config --project-name=[contrib module] --docroot=web  --php-version=8.1` or select these options when prompted using `ddev config`
    - Remove underscores in the project name, or replace with hyphens.
+   - See [Misc](#misc) for help on using alternate versions of Drupal core.
 5. Run `ddev get ddev/ddev-drupal-contrib`
 6. Run `ddev start`
 7. Run `ddev poser`
@@ -51,7 +52,7 @@ Run tests on the `web/modules/custom` directory:
 - Optional: [Install the ddev-selenium-standalone-chrome extension for FunctionalJavascript and Nightwatch tests](https://github.com/ddev/ddev-selenium-standalone-chrome).
 - Optional: [Install the ddev-mkdocs extension for local preview of your docs site](https://github.com/nireneko/ddev-mkdocs). Drupal.org's Gitlab CI can [automatically publish your site](https://project.pages.drupalcode.org/gitlab_templates/jobs/pages/).
 - Optional. Commit the changes in the `.ddev` folder after this plugin installs. This saves other users from having to install this integration.
-- Set `_TARGET_CORE=^11` (or similar) in your DDEV config to specify a different version of Drupal core. This adds the corresponding constraint of `drupal/core-recommended` to the generated `composer.json`.
+- Set `_TARGET_CORE=^11` (or similar) in your DDEV config to specify a different version of Drupal core - `ddev config --web-environment-add=_TARGET_CORE=11`. This adds the corresponding constraint of `drupal/core-recommended` to the generated `composer.json`.
 - This project should work for any contrib project, including those that haven't [opted into Gitlab CI](https://www.drupal.org/project/infrastructure/issues/3261803). One advantage of that is that failures in CI are more likely to be reproducible locally when using this integration.
 - If you add/remove a root file or directory, re-symlink root files via EITHER of these methods
   - `ddev restart`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DDEV integration for developing Drupal contrib projects. As a general philosophy
 1. If you haven't already, [install Docker and DDEV](https://ddev.readthedocs.io/en/latest/users/install/)
 2. `git clone` your contrib module
 3. cd [contrib module directory]
-4. Configure DDEV for Drupal 10 using `ddev config --project-name=[contrib module] --project-type=drupal10 --docroot=web --create-docroot --php-version=8.1` or select these options when prompted using `ddev config`
+4. Configure DDEV for Drupal 10 using `ddev config --project-name=[contrib module] --docroot=web  --php-version=8.1` or select these options when prompted using `ddev config`
    - Remove underscores in the project name, or replace with hyphens.
 5. Run `ddev get ddev/ddev-drupal-contrib`
 6. Run `ddev start`
@@ -51,7 +51,7 @@ Run tests on the `web/modules/custom` directory:
 - Optional: [Install the ddev-selenium-standalone-chrome extension for FunctionalJavascript and Nightwatch tests](https://github.com/ddev/ddev-selenium-standalone-chrome).
 - Optional: [Install the ddev-mkdocs extension for local preview of your docs site](https://github.com/nireneko/ddev-mkdocs). Drupal.org's Gitlab CI can [automatically publish your site](https://project.pages.drupalcode.org/gitlab_templates/jobs/pages/).
 - Optional. Commit the changes in the `.ddev` folder after this plugin installs. This saves other users from having to install this integration.
-- This project reads your `project_type` from DDEV and fetches adds the corresponding version of `drupal/core-recommended` to `composer.json`. if you are doing something non-standard with project_type, don't use `ddev poser` command.
+- Set `_TARGET_CORE=^11` (or similar) in your DDEV config to specify a different version of Drupal core. This adds the corresponding constraint of `drupal/core-recommended` to the generated `composer.json`.
 - This project should work for any contrib project, including those that haven't [opted into Gitlab CI](https://www.drupal.org/project/infrastructure/issues/3261803). One advantage of that is that failures in CI are more likely to be reproducible locally when using this integration.
 - If you add/remove a root file or directory, re-symlink root files via EITHER of these methods
   - `ddev restart`

--- a/commands/web/expand-composer-json
+++ b/commands/web/expand-composer-json
@@ -9,9 +9,6 @@
 ## ExecRaw: true
 
 export _WEB_ROOT=$DDEV_DOCROOT
-[[ $DDEV_PROJECT_TYPE == "drupal10" ]] && export _TARGET_CORE=^10
-[[ $DDEV_PROJECT_TYPE == "drupal9" ]] && export _TARGET_CORE=^9
-[[ $DDEV_PROJECT_TYPE == "drupal8" ]] && export _TARGET_CORE=^8
 cd "$DDEV_COMPOSER_ROOT" || exit
 curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/expand_composer_json.php
 php expand_composer_json.php "$DDEV_SITENAME"

--- a/config.contrib.yaml
+++ b/config.contrib.yaml
@@ -1,6 +1,8 @@
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib
 web_environment:
+  # If desired, override to a different version of Drupal core in via the project's DDEV config
+  - _TARGET_CORE=^10
   - SIMPLETEST_DB=mysql://db:db@db/db
   - SIMPLETEST_BASE_URL=http://web
   - BROWSERTEST_OUTPUT_DIRECTORY=/tmp

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -22,7 +22,7 @@ teardown() {
   cd ${TESTDIR}/${PROJNAME}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR}/${PROJNAME} ($(pwd))" >&3
   ddev get ${DIR}
-  ddev config --nodejs-version 18
+  ddev config --auto
   ddev start
   ddev expand-composer-json
   ddev composer install

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -22,7 +22,7 @@ teardown() {
   cd ${TESTDIR}/${PROJNAME}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR}/${PROJNAME} ($(pwd))" >&3
   ddev get ${DIR}
-  ddev config --nodejs-version 18 --project-type=drupal10
+  ddev config --nodejs-version 18
   ddev start
   ddev expand-composer-json
   ddev composer install


### PR DESCRIPTION
Issue discussion at #38

This is my proposal for version detection. Default to 10 (until 11 is released), and ask user to override via ddev config as needed. No more looking at DDEV_PROJECT_TYPE.

I'm unsure how best to override the env variable that this project's config.contrib.yaml. Supplies. Can user do that in their project's config.yaml, or do they need to create a config.zz.yaml?