### PR TITLE
Add 'drupal' ProjectType in expand-composer-json

### DIFF
--- a/commands/web/expand-composer-json
+++ b/commands/web/expand-composer-json
@@ -5,7 +5,7 @@
 ## Description: Add Drupal core and other needed dependencies.
 ## Usage: expand-composer-json [flags] [PROJECT_NAME]
 ## Example: "ddev expand-composer-json ctools"
-## ProjectTypes: drupal8,drupal9,drupal10
+## ProjectTypes: drupal,drupal8,drupal9,drupal10
 ## ExecRaw: true
 
 export _WEB_ROOT=$DDEV_DOCROOT


### PR DESCRIPTION
## The Issue
The 'drupal' ProjectType was introduced in ddev v1.23.0 and will eventually replace drupal8, drupal9, and drupal10 ProjectTypes.

## How This PR Solves The Issue
This PR adds the 'drupal' ProjectType in the annotation.

## Related Issue Link(s)
#45 is where the change was originally made but was overlooked when closing the PR.


