### PR TITLE
Exclude .ddev/* from Composer package manager builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+#ddev-generated: by https://github.com/ddev/ddev-drupal-contrib
+# You can remove the above line if you want to edit and maintain this file yourself.
+
+# Exclude .ddev/* from Composer package manager builds.
+* export-ignore

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Run tests on the `web/modules/custom` directory:
 
 - Optional: [Install the ddev-selenium-standalone-chrome extension for FunctionalJavascript and Nightwatch tests](https://github.com/ddev/ddev-selenium-standalone-chrome).
 - Optional: [Install the ddev-mkdocs extension for local preview of your docs site](https://github.com/nireneko/ddev-mkdocs). Drupal.org's Gitlab CI can [automatically publish your site](https://project.pages.drupalcode.org/gitlab_templates/jobs/pages/).
-- Optional. Commit the changes in the `.ddev` folder after this plugin installs. This saves other users from having to install this integration.
+- Optional. Commit the changes in the `.ddev` folder after this plugin installs. This saves other users from having to install this integration. Note: Committing the .ddev/.gitattributes file provided by this addon will tell Drupal package management to exclude the contents of .ddev/ when generating tarballs and composer packages.
 - To customize the version of Drupal core, create a config.local.yaml (or [any filename lexicographically after config.contrib.yaml](https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files)) with contents similar to
 ```
 web_environment:

--- a/install.yaml
+++ b/install.yaml
@@ -2,3 +2,4 @@ name: ddev-drupal-contrib
 project_files:
   - commands
   - config.contrib.yaml
+  - .gitattributes


### PR DESCRIPTION
## The Issue

The Ddev Drupal Contrib add-on encourages folks to commit the `.ddev/` folder to their projects. This methodology will only become more common as Ddev becomes the gold-standard for Drupal contrib work.

However, composer and tarball archives created on Drupal.org infrastructure generally should not include .ddev/ folder contents since packages are intended for distribution and use on websites, not for developing the module itself (which would be done via GitLab).

## How This PR Solves The Issue

Include a .ddev/.gitattributes file that is intended to be committed, along with the other .ddev commands added via this addon. 

The .gitattributes file contains a directive to exclude the contents of the .ddev/ folder when used by package manager tooling that leverage `git archive` with the `--workspace-attributes` option.

## Manual Testing Instructions

On a Drupal contrib project that is already using ddev-drupal-contrib addon, commit the the .ddev/.gitattributes file with the following line to your repository:

```
* export-ignore
```

Optionally create a MR or just push to your latest dev branch.  Wait for Drupal.org Infrastructure composer package manager to finish the build.  Confirm that the contents of the .ddev/ folder do not exist in the tarball.  Require the latest -dev branch with composer on a mock website project. Confirm that the web/modules/contrib/your_module/.ddev/ is empty.    


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

