### PR TITLE
fix: install.yaml needs to list commands separately to avoid removal of `commands` directory

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,12 @@
 name: ddev-drupal-contrib
 project_files:
-  - commands
+  - commands/web/eslint
+  - commands/web/expand-composer-json
+  - commands/web/nightwatch
+  - commands/web/phpcbf
+  - commands/web/phpcs
+  - commands/web/phpunit
+  - commands/web/poser
+  - commands/web/stylelint
+  - commands/web/symlink-project
   - config.contrib.yaml


### PR DESCRIPTION
## The Issue

The current install.yaml uses `commands` in the project_files section. 

Unfortunately, that means that when the add-on is uninstalled, it will remove everything in the `commands` directory.

Using directories in `project_files` is OK if they're directories created/maintained by the add-on, but in this case, the directory is one that is shared more generally.

## How This PR Solves The Issue

List the items in commands/web individually.

## Manual Testing Instructions

* Install the add-on and then remove it. It should not remove existing commands/web contents

You can install with `ddev get https://github.com/rfay/ddev-drupal-contrib/tarball/20240606_explicit_commands`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

