### PR TITLE
Remove `--testdox` parameter from phpunit command

### DIFF
--- a/commands/web/phpunit
+++ b/commands/web/phpunit
@@ -18,5 +18,5 @@ if [ -f "phpunit.xml" ]; then
     phpunit "$@"
 else
     # Bootstrap Drupal tests and run all custom module tests.
-    phpunit --printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" --bootstrap $PWD/$DDEV_DOCROOT/core/tests/bootstrap.php --testdox $DDEV_DOCROOT/modules/custom "$@"
+    phpunit --printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" --bootstrap $PWD/$DDEV_DOCROOT/core/tests/bootstrap.php $DDEV_DOCROOT/modules/custom "$@"
 fi


### PR DESCRIPTION
## The Issue
The test output from `ddev phpunit` has the following problems:
- The previous exception is not shown, see https://github.com/sebastianbergmann/phpunit/issues/5863
- The "HTML output was generated" message from Drupal is not shown.

How does this happen?
Currently the `phpunit` command from this package calls phpunit with a `--testdox` parameter.
This parameter replaces the printer we previously set with `--printer`.

## How This PR Solves The Issue
By removing the `--testdox` argument, we fall back to the Drupal output printer.
A developer can still manually append `--testdox` by running `ddev phpunit --testdox`, if they prefer that format.

## Manual Testing Instructions
In a project with the ddev-drupal-contrib extension, create a test case like this:
```php
use PHPUnit\Framework\TestCase;

class ExampleUnitTest extends TestCase {
  public function testFoo() {
    throw new \Exception('Outer', previous: new \Exception('Inner'));
  }
}
```
Optionally, add a Drupal web test (e.g. FunctionalJavascript) with a failed assertion.

Run `ddev phpunit`.

Expected:
- For the ExampleUnitTest, we see the message and backtrace for "Inner" and "Outer" exceptions in the phpunit output.
- For the web test, we see a section with "HTML output was generated", with a list of links.

Actual:
- For the ExampleUnitTest, we don't see anything about "Inner" exception or its backtrace.
- For the web test, we don't see the "HTML output was generated" section.

## Automated Testing Overview
Not yet. I first want to see what fails by doing this change..

## Related Issue Link(s)
Interesting post: https://github.com/ddev/ddev-drupal-contrib/issues/29#issuecomment-2035861699

> Update .ddev/commands/web/phpunit command
> 
> Remove #ddev-generated from the top (line 3)
> Remove --testdox from line 22

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

