### PR TITLE
Updated symlink-project command description in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This project provides the following DDEV container commands.
   - Creates a temporary [composer.contrib.json](https://getcomposer.org/doc/03-cli.md#composer) so that `drupal/core-recommended` becomes a dev dependency. This way the composer.json from the module is untouched.
   - Runs `composer install` AND `yarn install` so that dependencies are available.
   - Note: it is perfectly acceptable to skip this command and edit the require-dev of composer.json by hand.
-- [ddev symlink-project](https://github.com/ddev/ddev-drupal-contrib/blob/main/commands/web/symlink-project). This symlinks the top level files of your project into web/modules/custom so that Drupal finds your module. This command runs automatically on every `ddev start`. See codebase image below.
+- [ddev symlink-project](https://github.com/ddev/ddev-drupal-contrib/blob/main/commands/web/symlink-project). Symlinks the top level files of your project into web/modules/custom so that Drupal finds your module. This command runs automatically on every `ddev start` _as long as Composer has generated `vendor/autoload.php`_ which occurs during `composer install/update`. See codebase image below.
 
 Run tests on the `web/modules/custom` directory:
 


### PR DESCRIPTION
## The Issue
The README says the following about the `symlink-project` command:

> [ddev symlink-project](https://github.com/ddev/ddev-drupal-contrib/blob/main/commands/web/symlink-project). This symlinks the top level files of your project into web/modules/custom so that Drupal finds your module. **_This command runs automatically on every ddev start._** See codebase image below.

This can cause some confusion as it will not run automatically if `composer install/update` has not already been run so that Composer can generate the `vendor/autoload.php` file.

## How This PR Solves The Issue
Updates README to clarify that this command will not run successfully if `vendor/autoload.php` has not already been generated.

## Manual Testing Instructions
N/A

## Automated Testing Overview
N/A

## Related Issue Link(s)
Resolves https://github.com/ddev/ddev-drupal-contrib/issues/66

## Release/Deployment Notes
N/A
