### PR TITLE
Project name at the end of cli command for ease of copy paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DDEV integration for developing Drupal contrib projects. As a general philosophy
 1. If you haven't already, [install Docker and DDEV](https://ddev.readthedocs.io/en/latest/users/install/)
 2. `git clone` your contrib module
 3. cd [contrib module directory]
-4. Configure DDEV for Drupal using `ddev config --project-name=[contrib module] --project-type=drupal --docroot=web  --php-version=8.2` or select these options when prompted using `ddev config`
+4. Configure DDEV for Drupal using `ddev config --project-type=drupal --docroot=web  --php-version=8.2 --project-name=[contrib module]` or select these options when prompted using `ddev config`
    - Remove underscores in the project name, or replace with hyphens.
    - See [Misc](#misc) for help on using alternate versions of Drupal core.
 5. Run `ddev get ddev/ddev-drupal-contrib`


### PR DESCRIPTION
## The Issue
Not an issue at all, feel free to ignore the PR.

Move project name to the end of the command, so when you copy the command you can just do bunch of backspaces and enter the project name. :)

## How This PR Solves The Issue
Updates the README