### PR TITLE
Improve documentation for how to change the version of Drupal core, fixes #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,18 +53,23 @@ Run tests on the `web/modules/custom` directory:
 - Optional: [Install the ddev-selenium-standalone-chrome extension for FunctionalJavascript and Nightwatch tests](https://github.com/ddev/ddev-selenium-standalone-chrome).
 - Optional: [Install the ddev-mkdocs extension for local preview of your docs site](https://github.com/nireneko/ddev-mkdocs). Drupal.org's Gitlab CI can [automatically publish your site](https://project.pages.drupalcode.org/gitlab_templates/jobs/pages/).
 - Optional. Commit the changes in the `.ddev` folder after this plugin installs. This saves other users from having to install this integration.
-- To customize the version of Drupal core, create a config.local.yaml (or [any filename lexicographically after config.contrib.yaml](https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files)) with contents similar to
-```
-web_environment:
-  - DRUPAL_CORE=^9
-```
-This adds the value as a constraint of `drupal/core-recommended` to the generated `composer.json`.
 - If you add/remove a root file or directory, re-symlink root files via EITHER of these methods
   - `ddev restart`
   - `ddev symlink-project`
 - `cweagans/composer-patches:^1` is added by `ddev poser` so feel free to configure any patches that your project needs.
 - Any development dependencies (e.g. Drush) should be manually added to require-dev in your project's composer.json file. Don't use the `composer require` command to do that.
 
+### Changing the Drupal core version
+
+- To customize the version of Drupal core, create a `.ddev/config.local.yaml` (or [any filename lexicographically following config.contrib.yaml](https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files)) with contents similar to
+```
+web_environment:
+  - DRUPAL_CORE=^11
+```
+
+After creating this file, run `ddev restart` and then `ddev poser` to update the Drupal core version.
+
+If Drupal core cannot be changed because the project is using an unsupported version of PHP, `ddev poser` will show a `composer` error. In that case, open `.ddev/config.yaml` and change the `PHP_VERSION` to a supported version; then run `ddev restart` and `ddev poser` again.  Note that the project PHP version is set in `.ddev/config.yaml`, while the core version to use is set in `.ddev/config.local.yaml`. 
 
 ## Example of successful test
 

--- a/config.contrib.yaml
+++ b/config.contrib.yaml
@@ -1,7 +1,8 @@
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib
 web_environment:
-  # If desired, override to a different version of Drupal core in via the project's DDEV config
+  # To change the Drupal core version, see the README:
+  # https://github.com/ddev/ddev-drupal-contrib/blob/main/README.md#changing-the-drupal-core-version
   - DRUPAL_CORE=^10
   - SIMPLETEST_DB=mysql://db:db@db/db
   - SIMPLETEST_BASE_URL=http://web


### PR DESCRIPTION
## The Issue

* https://github.com/ddev/ddev-drupal-contrib/issues/75

## How This PR Solves The Issue

I moved the information on changing the core version to a separate section and rewrote it.  This is what worked for me, but I find it strange that the PHP_VERSION is set in .config.yaml, while the core version to override is set in .config.local.yaml.