### PR TITLE
fix: eslint/styleint not available error message

### DIFF
--- a/commands/web/eslint
+++ b/commands/web/eslint
@@ -15,6 +15,6 @@ if "$DDEV_DOCROOT/core/node_modules/.bin/eslint" --version >/dev/null ; then
   cd "$DDEV_DOCROOT/modules/custom/$DDEV_SITENAME" || exit
   "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/eslint" --no-error-on-unmatched-pattern --ignore-pattern="*.es6.js" --resolve-plugins-relative-to=$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core --ext=.js,.yml . "$@"
 else
-  echo "eslint is not available. You may need to 'ddev yarn --cwd $DDEV_DOCROOT/core install'"
+  echo "eslint is not available. You may need to 'cd web/core && ddev yarn install'"
   exit 1
 fi

--- a/commands/web/eslint
+++ b/commands/web/eslint
@@ -15,6 +15,6 @@ if "$DDEV_DOCROOT/core/node_modules/.bin/eslint" --version >/dev/null ; then
   cd "$DDEV_DOCROOT/modules/custom/$DDEV_SITENAME" || exit
   "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/eslint" --no-error-on-unmatched-pattern --ignore-pattern="*.es6.js" --resolve-plugins-relative-to=$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core --ext=.js,.yml . "$@"
 else
-  echo "eslint is not available. You may need to 'cd web/core && ddev yarn install'"
+  echo "eslint is not available. You may need to 'ddev exec \"cd web/core && yarn install\"'"
   exit 1
 fi

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -10,6 +10,6 @@
 if yarn --cwd "$DDEV_DOCROOT/core" stylelint --version >/dev/null ; then
   yarn --color --cwd "$DDEV_DOCROOT/core" --config ./.stylelintrc.json stylelint ../modules/custom/**/*.css "$@"
 else
-  echo "stylelint is not available. You may need to 'ddev yarn --cwd $DDEV_DOCROOT/core install'"
+  echo "stylelint is not available. You may need to 'ddev exec \"cd web/core && yarn install\"'"
   exit 1
 fi


### PR DESCRIPTION
`ddev yarn --cwd web/core install` doesn't work with D11, it does the cwd but then fail as install is being run with v1.x.

Instead suggest `ddev exec "cd web/core && yarn install"` which should work for either version.