### PR TITLE
Drupal 11 is the main stable branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DDEV integration for developing Drupal contrib projects. As a general philosophy
 1. If you haven't already, [install Docker and DDEV](https://ddev.readthedocs.io/en/latest/users/install/)
 2. `git clone` your contrib module
 3. cd [contrib module directory]
-4. Configure DDEV for Drupal using `ddev config --project-type=drupal --docroot=web --php-version=8.3 --project-name=[module]` or select these options when prompted using `ddev config`
+4. Configure DDEV for Drupal using `ddev config --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable --project-name=[module]` or select these options when prompted using `ddev config`
    - Remove underscores in the project name, or replace with hyphens. (DDEV will do this for you in v1.23.5+)
    - See [Misc](#misc) for help on using alternate versions of Drupal core.
 5. Run `ddev get ddev/ddev-drupal-contrib`

--- a/config.contrib.yaml
+++ b/config.contrib.yaml
@@ -3,7 +3,7 @@
 web_environment:
   # To change the Drupal core version, see the README:
   # https://github.com/ddev/ddev-drupal-contrib/blob/main/README.md#changing-the-drupal-core-version
-  - DRUPAL_CORE=^10
+  - DRUPAL_CORE=^11
   - SIMPLETEST_DB=mysql://db:db@db/db
   - SIMPLETEST_BASE_URL=http://web
   - BROWSERTEST_OUTPUT_DIRECTORY=/tmp

--- a/tests/_common.bash
+++ b/tests/_common.bash
@@ -10,7 +10,7 @@ _common_setup() {
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cp -R ${DIR}/tests/testdata/test_drupal_contrib/* ${TESTDIR}
   cd ${TESTDIR}
-  ddev config  --project-name=${PROJNAME} --project-type=drupal --docroot=web
+  ddev config  --project-name=${PROJNAME} --project-type=drupal --docroot=web --php-version=8.3
   if [ -n "$TEST_DRUPAL_CORE" ] && [ "$TEST_DRUPAL_CORE" != "default" ]; then
     echo -e "web_environment:\n    - DRUPAL_CORE=^${TEST_DRUPAL_CORE}" > .ddev/config.~overrides.yaml
   fi

--- a/tests/_common.bash
+++ b/tests/_common.bash
@@ -10,7 +10,7 @@ _common_setup() {
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cp -R ${DIR}/tests/testdata/test_drupal_contrib/* ${TESTDIR}
   cd ${TESTDIR}
-  ddev config  --project-name=${PROJNAME} --project-type=drupal --docroot=web --php-version=8.3
+  ddev config  --project-name=${PROJNAME} --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable
   if [ -n "$TEST_DRUPAL_CORE" ] && [ "$TEST_DRUPAL_CORE" != "default" ]; then
     echo -e "web_environment:\n    - DRUPAL_CORE=^${TEST_DRUPAL_CORE}" > .ddev/config.~overrides.yaml
   fi

--- a/tests/full.bats
+++ b/tests/full.bats
@@ -7,9 +7,9 @@ setup_file() {
   fi
   load '_common.bash'
   _common_setup
-  ddev config --php-version=8.2
-  if [ "$TEST_DRUPAL_CORE" = "11" ]; then
-    ddev config --php-version=8.3 --corepack-enable
+  if [ "$TEST_DRUPAL_CORE" = "10" ]; then
+    # Test D10 with older PHP version and corepack-disabled
+    ddev config --php-version=8.2 --corepack-enable=false
   fi
   ddev start
 }


### PR DESCRIPTION
## The Issue

Drupal 11 is the main stable branch. This already happens in Drupal GitLab CI, see https://git.drupalcode.org/project/gitlab_templates/-/merge_requests/242

## How This PR Solves The Issue

Installs by default with Drupal 11. 

## Manual Testing Instructions

On a contrib, configure DDEV with /ddev/ddev-drupal-contrib and run `ddev poser`. You should get a D11 site by default.

## Automated Testing Overview

Should work

## Related Issue Link(s)

https://git.drupalcode.org/project/gitlab_templates/-/merge_requests/242

## Release/Deployment Notes

None.
