### PR TITLE
Use same ESLint config as GitLab

### DIFF
--- a/commands/web/eslint
+++ b/commands/web/eslint
@@ -13,7 +13,7 @@ if "$DDEV_DOCROOT/core/node_modules/.bin/eslint" --version >/dev/null ; then
   test -e .prettierignore || echo '*.yml' > .prettierignore
   # Change directory to the project root folder
   cd "$DDEV_DOCROOT/modules/custom/${DDEV_SITENAME//-/_}" || exit
-  "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/eslint" --no-error-on-unmatched-pattern --ignore-pattern="*.es6.js" --resolve-plugins-relative-to=$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core --ext=.js,.yml . "$@"
+  "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/eslint" --config="../../../core/.eslintrc.passing.json" --no-error-on-unmatched-pattern --ignore-pattern="*.es6.js" --resolve-plugins-relative-to=$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core --ext=.js,.yml . "$@"
 else
   echo "eslint is not available. You may need to 'ddev exec \"cd $DDEV_DOCROOT/core && yarn install\"'"
   exit 1


### PR DESCRIPTION
## The Issue

GitLab Templates uses `core/.eslintrc.passing.json` configuration. Quoting from https://git.drupalcode.org/project/gitlab_templates/-/blob/main/docs/jobs/eslint.md?ref_type=heads#eslint

> Your project does not need a `.eslintrc.json` file because a default one matching Core's standards `core/.eslintrc.passing.json` is used. If you do create a `.eslintrc.json` file then it only needs to contain the specific rules that you want to override, because all other rules will be inherited due to ESLint's cascading configuration.

The `core/.eslintrc.passing.json` config includes/merges `core/.eslintrc.json` and `core/..eslintrc.jquery.json`.

But this add-on only uses `core/.eslintrc.json`, meaning `core/.eslintrc.jquery.json` is ignored. It happens that you test locally with `ddev eslint` but in CI pipeline you will get failures caused by running `core/.eslintrc.jquery.json`

## How This PR Solves The Issue

Aligns `ddev eslint` with GitLab Templates.

## Manual Testing Instructions

* Run `ddev eslint` against JS with a lot of jQuery. The test passed.
* Check in pipeline the failures.

## Automated Testing Overview

N/A

## Related Issue Link(s)

None

## Release/Deployment Notes

N/A
