### PR TITLE
fix: use $DDEV_DOCROOT in phpcs and phpcbf commands

### DIFF
--- a/commands/web/phpcbf
+++ b/commands/web/phpcbf
@@ -12,4 +12,4 @@ if ! command -v phpcbf >/dev/null; then
   exit 1
 fi
 test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpcs.xml.dist
-phpcbf -s --report-full --report-summary --report-source web/modules/custom "$@"
+phpcbf -s --report-full --report-summary --report-source $DDEV_DOCROOT/modules/custom "$@"

--- a/commands/web/phpcs
+++ b/commands/web/phpcs
@@ -12,4 +12,4 @@ if ! command -v phpcs >/dev/null; then
   exit 1
 fi
 test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpcs.xml.dist
-phpcs -s --report-full --report-summary --report-source web/modules/custom --ignore=*/.ddev/* "$@"
+phpcs -s --report-full --report-summary --report-source $DDEV_DOCROOT/modules/custom --ignore=*/.ddev/* "$@"


### PR DESCRIPTION
## The Issue
phpcs and phpcs commands are using a hardcoding docroot.

## How This PR Solves The Issue
Uses $DDEV_DOCROOT

## Manual Testing Instructions
Uses a docroot different than web/

## Automated Testing Overview

## Related Issue Link(s)

## Release/Deployment Notes


