### PR TITLE
fix: remove ProjectTypes from phpstan command

### DIFF
--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -5,7 +5,6 @@
 ## Description: Run phpstan inside the web container
 ## Usage: phpstan [flags] [args]
 ## Example: "ddev phpstan" or "ddev phpstan -n"
-## ProjectTypes: drupal,drupal8,drupal9,drupal10
 ## ExecRaw: true
 
 if ! command -v phpstan >/dev/null; then


### PR DESCRIPTION
## The Issue

In DDEV v1.24.0 (HEAD) the `drupal111` project type becomes "normal" for D11, and is autodetected in ddev-drupal-contrib tests.

The phpstan command provided by this add-on had a `# ProjectTypes: drupal,drupal8,drupal9,drupal10` which isn't very useful. (That directive is intended to not clog up the `ddev help` when using project types other than Drupal*)

Current [tests using DDEV HEAD](https://github.com/ddev/ddev-drupal-contrib/actions/runs/12065240371/job/33643600489) are failing with "# Command 'phpstan' is not available for the 'drupal11' project type."

## How This PR Solves The Issue

Remove the ProjectTypes restriction on this one command. As with the rest of the commands in this add-on, it seems people would not have installed this add-on if they weren't using Drupal.

## Manual Testing Instructions

Install add-on
Restart
`ddev phpstan`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

