### PR TITLE
Replace PHPStan baseline placeholder

### DIFF
--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -12,6 +12,8 @@ if ! command -v phpstan >/dev/null; then
   exit 1
 fi
 test -e phpstan.neon || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpstan.neon
+# See https://git.drupalcode.org/project/gitlab_templates/-/commit/a107b7f1f79af12e0b09f70be47b68e3f69b4504
+sed -i 's/BASELINE_PLACEHOLDER/phpstan-baseline.neon/g' phpstan.neon
 # Add an empty baseline file to ensure it exists.
 test -e phpstan-baseline.neon || touch phpstan-baseline.neon
 phpstan analyse $DDEV_DOCROOT/modules/custom "$@"


### PR DESCRIPTION
## The Issue

The GitLab Templates commit [a107b7f1f7](https://git.drupalcode.org/project/gitlab_templates/-/commit/a107b7f1f79af12e0b09f70be47b68e3f69b4504) introduced this error when running PHPStan:

```bash
$ ddev phpstan
Note: Using configuration file /var/www/html/phpstan.neon.
File '/var/www/html/BASELINE_PLACEHOLDER' is missing or is not readable.
```

## How This PR Solves The Issue

The `phpstan` command now replaces `BASELINE_PLACEHOLDER` with `phpstan-baseline.neon`.

## Manual Testing Instructions

With the `main` branch, run `ddev phpstan`. You should see the error. Looking into phpstan.neon you will see the string BASELINE_PLACEHOLDER
Use the PR branch and re-run. No error. The BASELINE_PLACEHOLDER string is replaced with phpstan-baseline.neon inside phpstan.neon

## Automated Testing Overview

No automated tests.

## Related Issue Link(s)

* https://www.drupal.org/project/gitlab_templates/issues/3397162

## Release/Deployment Notes

N/A
