### PR TITLE
fix: adapt to https://git.drupalcode.org/project/gitlab_templates/-/commit/e32e8cf change

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ In `.ddev/config.local.yaml` set the location relative to webroot (which usually
 ```
 web_environment:
   - ...
-  - DDEV_DRUPAL_CONTRIB_SYMLINK_DEST=modules
+  - DRUPAL_PROJECTS_PATH=modules
 ```
 
 Then restart DDEV by running `ddev restart`.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If Drupal core cannot be changed because the project is using an unsupported ver
 
 ### Changing the symlink location
 
-In `.ddev/config.local.yaml` set the location relative to webroot (which usually is `web/`)
+In `.ddev/config.local.yaml` set the location relative to webroot (which usually is `web/`). Defaults to `modules/custom`
 ```
 web_environment:
   - ...

--- a/README.md
+++ b/README.md
@@ -71,17 +71,32 @@ Run tests on the `web/modules/custom` directory:
 - `cweagans/composer-patches:^1` is added by `ddev poser` so feel free to configure any patches that your project needs.
 - Any development dependencies (e.g. Drush) should be manually added to require-dev in your project's composer.json file. Don't use the `composer require` command to do that.
 
+## Changing defaults
+
+Override any environment variable value from [.ddev/config.contrib.yaml](config.contrib.yaml) by creating a `.ddev/config.local.yaml` (or [any filename lexicographically following config.contrib.yaml](https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files)) file which has the same structure as [.ddev/config.contrib.yaml](config.contrib.yaml). Add your overrides under `web_environment`. 
+
 ### Changing the Drupal core version
 
-- To customize the version of Drupal core, create a `.ddev/config.local.yaml` (or [any filename lexicographically following config.contrib.yaml](https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files)) with contents similar to
+In `.ddev/config.local.yaml` set the Drupal core version:
 ```
 web_environment:
   - DRUPAL_CORE=^11
 ```
 
-After creating this file, run `ddev restart` and then `ddev poser` to update the Drupal core version.
+Then run `ddev restart` and then `ddev poser` to update the Drupal core version.
 
 If Drupal core cannot be changed because the project is using an unsupported version of PHP, `ddev poser` will show a `composer` error. In that case, open `.ddev/config.yaml` and change the `PHP_VERSION` to a supported version; then run `ddev restart` and `ddev poser` again.  Note that the project PHP version is set in `.ddev/config.yaml`, while the core version to use is set in `.ddev/config.local.yaml`. 
+
+### Changing the symlink location
+
+In `.ddev/config.local.yaml` set the location relative to webroot (which usually is `web/`)
+```
+web_environment:
+  - ...
+  - DDEV_DRUPAL_CONTRIB_SYMLINK_DEST=modules
+```
+
+Then restart DDEV by running `ddev restart`.
 
 ## Example of successful test
 

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -8,6 +8,8 @@
 ## ExecRaw: true
 
 export _WEB_ROOT=$DDEV_DOCROOT
+export DRUPAL_PROJECTS_PATH=modules/custom
+
 #todo use more dynamic ref.
 cd "$DDEV_COMPOSER_ROOT" || exit
 curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/symlink_project.php

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -14,5 +14,5 @@ curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/s
 
 # Symlink name using underscores.
 # @see https://www.drupal.org/docs/develop/creating-modules/naming-and-placing-your-drupal-module
-php "symlink_project.php ${DDEV_SITENAME//-/_} ${DDEV_DRUPAL_CONTRIB_SYMLINK_DEST}"
+php symlink_project.php ${DDEV_SITENAME//-/_} ${DDEV_DRUPAL_CONTRIB_SYMLINK_DEST}
 rm -f symlink_project.php

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -8,11 +8,12 @@
 ## ExecRaw: true
 
 export _WEB_ROOT=$DDEV_DOCROOT
+export DRUPAL_PROJECTS_PATH=$DDEV_DRUPAL_CONTRIB_SYMLINK_DEST
 #todo use more dynamic ref.
 cd "$DDEV_COMPOSER_ROOT" || exit
 curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/symlink_project.php
 
 # Symlink name using underscores.
 # @see https://www.drupal.org/docs/develop/creating-modules/naming-and-placing-your-drupal-module
-php symlink_project.php ${DDEV_SITENAME//-/_} ${DDEV_DRUPAL_CONTRIB_SYMLINK_DEST}
+php symlink_project.php "${DDEV_SITENAME//-/_}"
 rm -f symlink_project.php

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -8,7 +8,7 @@
 ## ExecRaw: true
 
 export _WEB_ROOT=$DDEV_DOCROOT
-export DRUPAL_PROJECTS_PATH=$DDEV_DRUPAL_CONTRIB_SYMLINK_DEST
+export DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 #todo use more dynamic ref.
 cd "$DDEV_COMPOSER_ROOT" || exit
 curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/symlink_project.php

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -14,5 +14,5 @@ curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/s
 
 # Symlink name using underscores.
 # @see https://www.drupal.org/docs/develop/creating-modules/naming-and-placing-your-drupal-module
-php symlink_project.php "${DDEV_SITENAME//-/_} ${DDEV_DRUPAL_CONTRIB_SYMLINK_DEST}"
+php "symlink_project.php ${DDEV_SITENAME//-/_} ${DDEV_DRUPAL_CONTRIB_SYMLINK_DEST}"
 rm -f symlink_project.php

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -8,13 +8,11 @@
 ## ExecRaw: true
 
 export _WEB_ROOT=$DDEV_DOCROOT
-export DRUPAL_PROJECTS_PATH=modules/custom
-
 #todo use more dynamic ref.
 cd "$DDEV_COMPOSER_ROOT" || exit
 curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/symlink_project.php
 
 # Symlink name using underscores.
 # @see https://www.drupal.org/docs/develop/creating-modules/naming-and-placing-your-drupal-module
-php symlink_project.php "${DDEV_SITENAME//-/_}"
+php symlink_project.php "${DDEV_SITENAME//-/_} ${DDEV_DRUPAL_CONTRIB_SYMLINK_DEST}"
 rm -f symlink_project.php

--- a/config.contrib.yaml
+++ b/config.contrib.yaml
@@ -8,6 +8,7 @@ web_environment:
   - SIMPLETEST_BASE_URL=http://web
   - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
   - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
+  - DDEV_DRUPAL_CONTRIB_SYMLINK_DEST=modules/custom
 hooks:
   post-start:
     - exec-host: |

--- a/config.contrib.yaml
+++ b/config.contrib.yaml
@@ -8,7 +8,6 @@ web_environment:
   - SIMPLETEST_BASE_URL=http://web
   - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
   - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
-  - DDEV_DRUPAL_CONTRIB_SYMLINK_DEST=modules/custom
 hooks:
   post-start:
     - exec-host: |

--- a/tests/_common.bash
+++ b/tests/_common.bash
@@ -12,7 +12,7 @@ _common_setup() {
   cd ${TESTDIR}
   ddev config  --project-name=${PROJNAME} --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable
   if [ -n "$TEST_DRUPAL_CORE" ] && [ "$TEST_DRUPAL_CORE" != "default" ]; then
-    echo -e "web_environment:\n    - DRUPAL_CORE=^${TEST_DRUPAL_CORE}" > .ddev/config.~overrides.yaml
+    echo -e "web_environment:\n    - DRUPAL_CORE=^${TEST_DRUPAL_CORE}\n    - DDEV_DRUPAL_CONTRIB_SYMLINK_DEST=modules/custom" > .ddev/config.~overrides.yaml
   fi
   ddev get ${DIR}
 }

--- a/tests/_common.bash
+++ b/tests/_common.bash
@@ -12,7 +12,7 @@ _common_setup() {
   cd ${TESTDIR}
   ddev config --project-name=${PROJNAME} --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable
   if [ -n "$TEST_DRUPAL_CORE" ] && [ "$TEST_DRUPAL_CORE" != "default" ]; then
-    echo -e "web_environment:\n    - DRUPAL_CORE=^${TEST_DRUPAL_CORE}\n    - DDEV_DRUPAL_CONTRIB_SYMLINK_DEST=modules/custom" > .ddev/config.~overrides.yaml
+    echo -e "web_environment:\n    - DRUPAL_CORE=^${TEST_DRUPAL_CORE}" > .ddev/config.~overrides.yaml
   fi
   ddev get ${DIR}
 }

--- a/tests/_common.bash
+++ b/tests/_common.bash
@@ -10,7 +10,7 @@ _common_setup() {
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cp -R ${DIR}/tests/testdata/test_drupal_contrib/* ${TESTDIR}
   cd ${TESTDIR}
-  ddev config  --project-name=${PROJNAME} --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable
+  ddev config --project-name=${PROJNAME} --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable
   if [ -n "$TEST_DRUPAL_CORE" ] && [ "$TEST_DRUPAL_CORE" != "default" ]; then
     echo -e "web_environment:\n    - DRUPAL_CORE=^${TEST_DRUPAL_CORE}\n    - DDEV_DRUPAL_CONTRIB_SYMLINK_DEST=modules/custom" > .ddev/config.~overrides.yaml
   fi


### PR DESCRIPTION
## The Issue

Symlinks are no more correctly created. This is caused by a GitLab Templates project change. See https://git.drupalcode.org/project/gitlab_templates/-/commit/e32e8cfd73bb570ea844ea560e8d46606dd196ca

## How This PR Solves The Issue

Provides a missing env var

## Manual Testing Instructions

With main branch
- Remove everything under web/modules/custom
- Run `ddev symlink-project`
You should see the module created directly under `web/`. It should be under `web/modules/custom`.

With this branch repeat the operations and check that the correct symlink is created.

## Automated Testing Overview

None.

## Related Issue Link(s)

N/A

## Release/Deployment Notes

None
