### PR TITLE
test: update bats to use `ddev add-on get`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,11 +15,11 @@ on:
         required: false
         default: false
 
-env:
-  # Allow ddev get to use a github token to prevent rate limiting by tests
-  DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-# Required permissions for keep-alive, used by ddev/github-action-add-on-test
+# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
   actions: write
 
@@ -34,16 +34,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: ddev/github-action-add-on-test@v2
-      with:
-        disable_checkout_action: true
-        ddev_version: ${{ matrix.ddev_version }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        debug_enabled: ${{ github.event.inputs.debug_enabled }}
-        addon_repository: ${{ env.GITHUB_REPOSITORY }}
-        addon_ref: ${{ env.GITHUB_REF }}
-        test_command: eval TEST_DRUPAL_CORE=${{ matrix.drupal_version }} ./tests/bats/bin/bats tests
+      - uses: ddev/github-action-add-on-test@v2
+        with:
+          disable_checkout_action: true
+          ddev_version: ${{ matrix.ddev_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          debug_enabled: ${{ github.event.inputs.debug_enabled }}
+          addon_repository: ${{ env.GITHUB_REPOSITORY }}
+          addon_ref: ${{ env.GITHUB_REF }}
+          test_command: eval TEST_DRUPAL_CORE=${{ matrix.drupal_version }} ./tests/bats/bin/bats tests

--- a/tests/_common.bash
+++ b/tests/_common.bash
@@ -6,7 +6,8 @@ _common_setup() {
   export PROJNAME=test-drupal-contrib
   export TESTDIR=~/tmp/${PROJNAME}
   mkdir -p $TESTDIR
-  export DDEV_NON_INTERACTIVE=true
+  export DDEV_NONINTERACTIVE=true
+  export DDEV_NO_INSTRUMENTATION=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cp -R ${DIR}/tests/testdata/test_drupal_contrib/* ${TESTDIR}
   cd ${TESTDIR}
@@ -14,7 +15,7 @@ _common_setup() {
   if [ -n "$TEST_DRUPAL_CORE" ] && [ "$TEST_DRUPAL_CORE" != "default" ]; then
     echo -e "web_environment:\n    - DRUPAL_CORE=^${TEST_DRUPAL_CORE}" > .ddev/config.~overrides.yaml
   fi
-  ddev get ${DIR}
+  ddev add-on get ${DIR}
 }
 
 _common_teardown() {


### PR DESCRIPTION
## The Issue

Tests use `ddev get`.

## How This PR Solves The Issue

Updates them to use `ddev add-on get`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

