### PR TITLE
refactor: use `#!/usr/bin/env bash` instead of `#!/bin/bash`

### DIFF
--- a/commands/web/eslint
+++ b/commands/web/eslint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib

--- a/commands/web/expand-composer-json
+++ b/commands/web/expand-composer-json
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib

--- a/commands/web/nightwatch
+++ b/commands/web/nightwatch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib

--- a/commands/web/phpcbf
+++ b/commands/web/phpcbf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib

--- a/commands/web/phpcs
+++ b/commands/web/phpcs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib

--- a/commands/web/phpunit
+++ b/commands/web/phpunit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib

--- a/commands/web/poser
+++ b/commands/web/poser
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib


### PR DESCRIPTION
## The Issue

`#!/bin/bash` doesn't work on NixOS.

## How This PR Solves The Issue

Uses `#!/usr/bin/env bash` for commands.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

