### PR TITLE
feat: use DRUPAL_PROJECTS_PATH for all commands. fixes #111

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project provides the following DDEV container commands.
   - Creates a temporary [composer.contrib.json](https://getcomposer.org/doc/03-cli.md#composer) so that `drupal/core-recommended` becomes a dev dependency. This way the composer.json from the module is untouched.
   - Runs `composer install` AND `yarn install` so that dependencies are available. Additional arguments to `ddev poser` like --prefer-source are passed along to `composer install`
   - Note: it is perfectly acceptable to skip this command and edit the require-dev of composer.json by hand.
-- [ddev symlink-project](https://github.com/ddev/ddev-drupal-contrib/blob/main/commands/web/symlink-project). Symlinks the top level files of your project into web/modules/custom so that Drupal finds your module. This command runs automatically on every `ddev start` _as long as Composer has generated `vendor/autoload.php`_ which occurs during `composer install/update`. See codebase image below.
+- [ddev symlink-project](https://github.com/ddev/ddev-drupal-contrib/blob/main/commands/web/symlink-project). Symlinks your project files into the configured location (defaults to `web/modules/custom`) so Drupal can find your module. This command runs automatically on every `ddev start` _as long as Composer has generated `vendor/autoload.php`_ which occurs during `composer install/update`. See codebase image below.
 
 Run tests on your project code (defaults to `web/modules/custom`, [configurable](#changing-the-symlink-location)):
 
@@ -48,7 +48,7 @@ Run tests on your project code (defaults to `web/modules/custom`, [configurable]
 - `ddev nightwatch` Run Nightwatch tests, requires [DDEV Selenium Standalone Chrome](https://github.com/ddev/ddev-selenium-standalone-chrome).
 - `ddev phpcs` Run [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 - `ddev phpcbf` Fix phpcs findings.
-- `ddev phpstan`. Run [phpstan](https://phpstan.org) on the web/modules/custom directory.
+- `ddev phpstan`. Run [phpstan](https://phpstan.org) on project files.
 - `ddev eslint` Run [ESLint](https://github.com/eslint/eslint) on JavaScript files.
 - `ddev stylelint` Run [Stylelint](https://github.com/stylelint/stylelint) on CSS files.
 
@@ -96,7 +96,7 @@ web_environment:
   - DRUPAL_PROJECTS_PATH=modules
 ```
 
-Then run `ddev restart` and then `ddev symlink-project` to update the symlink location.
+Then run `ddev restart` to update the symlink location.
 
 All [ddev-drupal-contrib commands](#commands) run against your project code in the configured symlink location.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ web_environment:
   - DRUPAL_PROJECTS_PATH=modules
 ```
 
-Then restart DDEV by running `ddev restart`.
+Then run `ddev restart` and then `ddev symlink-project` to update the symlink location.
+
+All [ddev-drupal-contrib commands](#commands) run against your project code in the configured symlink location.
+
+To use with Drupal themes, set `DRUPAL_PROJECTS_PATH=themes/custom` in your config.
 
 ## Example of successful test
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This project provides the following DDEV container commands.
   - Note: it is perfectly acceptable to skip this command and edit the require-dev of composer.json by hand.
 - [ddev symlink-project](https://github.com/ddev/ddev-drupal-contrib/blob/main/commands/web/symlink-project). Symlinks the top level files of your project into web/modules/custom so that Drupal finds your module. This command runs automatically on every `ddev start` _as long as Composer has generated `vendor/autoload.php`_ which occurs during `composer install/update`. See codebase image below.
 
-Run tests on the `web/modules/custom` directory:
+Run tests on your project code (defaults to `web/modules/custom`, [configurable](#changing-the-symlink-location)):
 
 - `ddev phpunit` Run [PHPUnit](https://github.com/sebastianbergmann/phpunit) tests.
 - `ddev nightwatch` Run Nightwatch tests, requires [DDEV Selenium Standalone Chrome](https://github.com/ddev/ddev-selenium-standalone-chrome).

--- a/commands/web/eslint
+++ b/commands/web/eslint
@@ -7,7 +7,6 @@
 ## Example: "ddev eslint"
 ## ExecRaw: true
 
-DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if "$DDEV_DOCROOT/core/node_modules/.bin/eslint" --version >/dev/null ; then
   # Configure prettier
   test -e .prettierrc.json || ln -s $DDEV_DOCROOT/core/.prettierrc.json .

--- a/commands/web/eslint
+++ b/commands/web/eslint
@@ -7,12 +7,13 @@
 ## Example: "ddev eslint"
 ## ExecRaw: true
 
+DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if "$DDEV_DOCROOT/core/node_modules/.bin/eslint" --version >/dev/null ; then
   # Configure prettier
   test -e .prettierrc.json || ln -s $DDEV_DOCROOT/core/.prettierrc.json .
   test -e .prettierignore || echo '*.yml' > .prettierignore
   # Change directory to the project root folder
-  cd "$DDEV_DOCROOT/modules/custom/${DDEV_SITENAME//-/_}" || exit
+  cd "$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH/${DDEV_SITENAME//-/_}" || exit
   "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/eslint" --config="../../../core/.eslintrc.passing.json" --no-error-on-unmatched-pattern --ignore-pattern="*.es6.js" --resolve-plugins-relative-to=$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core --ext=.js,.yml . "$@"
 else
   echo "eslint is not available. You may need to 'ddev exec \"cd $DDEV_DOCROOT/core && yarn install\"'"

--- a/commands/web/nightwatch
+++ b/commands/web/nightwatch
@@ -7,4 +7,5 @@
 ## Example: "ddev nightwatch"
 ## ExecRaw: true
 
-yarn --cwd "$DDEV_DOCROOT/core" test:nightwatch  "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/modules/custom/" "$@"
+DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
+yarn --cwd "$DDEV_DOCROOT/core" test:nightwatch  "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH/" "$@"

--- a/commands/web/nightwatch
+++ b/commands/web/nightwatch
@@ -7,5 +7,4 @@
 ## Example: "ddev nightwatch"
 ## ExecRaw: true
 
-DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 yarn --cwd "$DDEV_DOCROOT/core" test:nightwatch  "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH/" "$@"

--- a/commands/web/phpcbf
+++ b/commands/web/phpcbf
@@ -7,9 +7,10 @@
 ## Example: "ddev phpcbf" or "ddev phpcbf -n"
 ## ExecRaw: true
 
+DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if ! command -v phpcbf >/dev/null; then
   echo "phpcbf is not available. You may need to 'ddev composer install'"
   exit 1
 fi
 test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpcs.xml.dist
-phpcbf -s --report-full --report-summary --report-source $DDEV_DOCROOT/modules/custom "$@"
+phpcbf -s --report-full --report-summary --report-source $DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH "$@"

--- a/commands/web/phpcbf
+++ b/commands/web/phpcbf
@@ -7,7 +7,6 @@
 ## Example: "ddev phpcbf" or "ddev phpcbf -n"
 ## ExecRaw: true
 
-DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if ! command -v phpcbf >/dev/null; then
   echo "phpcbf is not available. You may need to 'ddev composer install'"
   exit 1

--- a/commands/web/phpcs
+++ b/commands/web/phpcs
@@ -7,9 +7,10 @@
 ## Example: "ddev phpcs" or "ddev phpcs -n"
 ## ExecRaw: true
 
+DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if ! command -v phpcs >/dev/null; then
   echo "phpcs is not available. You may need to 'ddev composer install'"
   exit 1
 fi
 test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpcs.xml.dist
-phpcs -s --report-full --report-summary --report-source $DDEV_DOCROOT/modules/custom --ignore=*/.ddev/* "$@"
+phpcs -s --report-full --report-summary --report-source $DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH --ignore=*/.ddev/* "$@"

--- a/commands/web/phpcs
+++ b/commands/web/phpcs
@@ -7,7 +7,6 @@
 ## Example: "ddev phpcs" or "ddev phpcs -n"
 ## ExecRaw: true
 
-DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if ! command -v phpcs >/dev/null; then
   echo "phpcs is not available. You may need to 'ddev composer install'"
   exit 1

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -7,6 +7,7 @@
 ## Example: "ddev phpstan" or "ddev phpstan -n"
 ## ExecRaw: true
 
+DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if ! command -v phpstan >/dev/null; then
   echo "phpstan is not available. You may need to 'ddev poser'"
   exit 1
@@ -16,4 +17,4 @@ test -e phpstan.neon || curl -OL https://git.drupalcode.org/project/gitlab_templ
 sed -i 's/BASELINE_PLACEHOLDER/phpstan-baseline.neon/g' phpstan.neon
 # Add an empty baseline file to ensure it exists.
 test -e phpstan-baseline.neon || touch phpstan-baseline.neon
-phpstan analyse $DDEV_DOCROOT/modules/custom "$@"
+phpstan analyse $DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH "$@"

--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -7,7 +7,6 @@
 ## Example: "ddev phpstan" or "ddev phpstan -n"
 ## ExecRaw: true
 
-DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if ! command -v phpstan >/dev/null; then
   echo "phpstan is not available. You may need to 'ddev poser'"
   exit 1

--- a/commands/web/phpunit
+++ b/commands/web/phpunit
@@ -7,7 +7,6 @@
 ## Example: "ddev phpunit" or "ddev phpunit --stop-on-failure"
 ## ExecRaw: true
 
-DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if ! command -v phpunit >/dev/null; then
   echo "phpunit is not available. You may need to 'ddev composer install'"
   exit 1

--- a/commands/web/phpunit
+++ b/commands/web/phpunit
@@ -7,6 +7,7 @@
 ## Example: "ddev phpunit" or "ddev phpunit --stop-on-failure"
 ## ExecRaw: true
 
+DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if ! command -v phpunit >/dev/null; then
   echo "phpunit is not available. You may need to 'ddev composer install'"
   exit 1
@@ -18,5 +19,5 @@ if [ -f "phpunit.xml" ]; then
     phpunit "$@"
 else
     # Bootstrap Drupal tests and run all custom module tests.
-    phpunit --bootstrap $PWD/$DDEV_DOCROOT/core/tests/bootstrap.php $DDEV_DOCROOT/modules/custom "$@"
+    phpunit --bootstrap $PWD/$DDEV_DOCROOT/core/tests/bootstrap.php $DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH "$@"
 fi

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -7,9 +7,10 @@
 ## Example: "ddev stylelint"
 ## ExecRaw: true
 
+DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if $DDEV_DOCROOT/core/node_modules/.bin/stylelint --version >/dev/null ; then
   # Change directory to the project root folder
-  cd "$DDEV_DOCROOT/modules/custom/${DDEV_SITENAME//-/_}" || exit
+  cd "$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH/${DDEV_SITENAME//-/_}" || exit
   "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/stylelint" --color --config "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/.stylelintrc.json" "./**/*.css" "$@"
 else
   echo "stylelint is not available. You may need to 'ddev exec \"cd $DDEV_DOCROOT/core && yarn install\"'"

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -7,7 +7,6 @@
 ## Example: "ddev stylelint"
 ## ExecRaw: true
 
-DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 if $DDEV_DOCROOT/core/node_modules/.bin/stylelint --version >/dev/null ; then
   # Change directory to the project root folder
   cd "$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH/${DDEV_SITENAME//-/_}" || exit

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -2,7 +2,7 @@
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib
-## Description: Symlink all root files/dirs into web.modules/custom/[PROJECT_NAME]
+## Description: Symlink all root files/dirs into web/modules/custom/[PROJECT_NAME]
 ## Usage: symlink-project [flags] [args]
 ## Example: "ddev symlink-project"
 ## ExecRaw: true

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -8,7 +8,6 @@
 ## ExecRaw: true
 
 export _WEB_ROOT=$DDEV_DOCROOT
-export DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
 #todo use more dynamic ref.
 cd "$DDEV_COMPOSER_ROOT" || exit
 curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/symlink_project.php

--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -2,7 +2,7 @@
 
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib
-## Description: Symlink all root files/dirs into web/modules/custom/[PROJECT_NAME]
+## Description: Symlink project files into the configured location (defaults to `web/modules/custom/[PROJECT_NAME]`)
 ## Usage: symlink-project [flags] [args]
 ## Example: "ddev symlink-project"
 ## ExecRaw: true

--- a/config.contrib.yaml
+++ b/config.contrib.yaml
@@ -10,7 +10,8 @@ web_environment:
   - SIMPLETEST_BASE_URL=http://web
   - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
   - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
-  # To change the symlink location, see: https://github.com/ddev/ddev-drupal-contrib/blob/main/README.md#changing-the-symlink-location
+  # To change the location of your project code, see the README:
+  # https://github.com/ddev/ddev-drupal-contrib/blob/main/README.md#changing-the-symlink-location
   - DRUPAL_PROJECTS_PATH=modules/custom
 hooks:
   post-start:

--- a/config.contrib.yaml
+++ b/config.contrib.yaml
@@ -1,5 +1,7 @@
 #ddev-generated
 ## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## To customize this configuration, see:
+## https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/
 web_environment:
   # To change the Drupal core version, see the README:
   # https://github.com/ddev/ddev-drupal-contrib/blob/main/README.md#changing-the-drupal-core-version
@@ -8,6 +10,8 @@ web_environment:
   - SIMPLETEST_BASE_URL=http://web
   - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
   - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
+  # To change the symlink location, see: https://github.com/ddev/ddev-drupal-contrib/blob/main/README.md#changing-the-symlink-location
+  - DRUPAL_PROJECTS_PATH=modules/custom
 hooks:
   post-start:
     - exec-host: |


### PR DESCRIPTION
## The Issue

- #111 

Leverage environment variable DRUPAL_PROJECTS_PATH in all custom ddev commands shipped with ddev-drupal-contrib.

## How This PR Solves The Issue

Adds the following line to all commands:
```
DRUPAL_PROJECTS_PATH=${DRUPAL_PROJECTS_PATH:-modules/custom}
```

so that the $DRUPAL_PROJECTS_PATH environment variable can be used, if defined in `.ddev/config.local.yaml`, instead of the hardcoded fallback value `modules/custom`.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/jameswilson/ddev-drupal-contrib/tarball/111-env-var-project-path
```

Set a custom symlink location in .ddev/config.local.yaml

```yaml
web_environment:
  - ...
  - DRUPAL_PROJECTS_PATH=modules
```

Restart, re-symlink, then run one of the additional commands, eg `eslint` (if your module has custom js).

```bash
ddev restart
ddev symlink-project
ddev eslint
```

## Automated Testing Overview

The existing integration from #101 does not have any test coverage for  DRUPAL_PROJECTS_PATH. And existing tests still hardcode the modules/custom folder. Happy to add a test if required, but since this is an environment variable, it's unclear how we would actually test this. Can environment variables be passed into `ddev` commands that run inside the web container on the fly?

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

No known impacts on other code or existing projects leveraging the ddev-drupal-contrib addon.  Existing projects that already leverage DRUPAL_PROJECTS_PATH should find that all of the bundled ddev command now work properly.
