### PR TITLE
Use DDEV_APPROOT instead

### DIFF
--- a/commands/web/nightwatch
+++ b/commands/web/nightwatch
@@ -7,4 +7,4 @@
 ## Example: "ddev nightwatch"
 ## ExecRaw: true
 
-yarn --cwd "$DDEV_DOCROOT/core" test:nightwatch  "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/modules/custom/" "$@"
+yarn --cwd "$DDEV_DOCROOT/core" test:nightwatch  "$DDEV_APPROOT/$DDEV_DOCROOT/modules/custom/" "$@"

--- a/install.yaml
+++ b/install.yaml
@@ -13,4 +13,4 @@ project_files:
   - commands/web/symlink-project
   - config.contrib.yaml
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.6'


### PR DESCRIPTION
Because

* DDEV_APPROOT: Absolute path to the project files within the web container
* DDEV_DOCROOT: Relative path from approot to docroot

https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/#environment-variables-provided

