### PR TITLE
Add dependency on ddev/ddev-selenium-standalone-chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DDEV integration for developing Drupal contrib projects. As a general philosophy
 4. Configure DDEV for Drupal using `ddev config --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable --project-name=[module]` or select these options when prompted using `ddev config`
    - Remove underscores in the project name, or replace with hyphens. (DDEV will do this for you.)
    - See [Misc](#misc) for help on using alternate versions of Drupal core.
-5. Run `ddev add-on get ddev/ddev-drupal-contrib`
+5. Run `ddev add-on get ddev/ddev-selenium-standalone-chrome ddev/ddev-drupal-contrib && ddev add-on get ddev/ddev-drupal-contrib`
 6. Run `ddev start`
 7. Run `ddev poser`
 8. Run `ddev symlink-project`

--- a/config.contrib.yaml
+++ b/config.contrib.yaml
@@ -8,10 +8,6 @@ web_environment:
   - DRUPAL_CORE=^11
   - # https://git.drupalcode.org/project/gitlab_templates/-/blob/1.9.6/scripts/expand_composer_json.php?ref_type=tags#L15
   - IGNORE_PROJECT_DRUPAL_CORE_VERSION=1
-  - SIMPLETEST_DB=mysql://db:db@db/db
-  - SIMPLETEST_BASE_URL=http://web
-  - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
-  - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
   # To change the location of your project code, see the README:
   # https://github.com/ddev/ddev-drupal-contrib/blob/main/README.md#changing-the-symlink-location
   - DRUPAL_PROJECTS_PATH=modules/custom

--- a/install.yaml
+++ b/install.yaml
@@ -14,3 +14,6 @@ project_files:
   - config.contrib.yaml
 
 ddev_version_constraint: '>= v1.24.6'
+
+dependencies:
+  - ddev-selenium-standalone-chrome

--- a/tests/_common.bash
+++ b/tests/_common.bash
@@ -15,6 +15,7 @@ _common_setup() {
   if [ -n "$TEST_DRUPAL_CORE" ] && [ "$TEST_DRUPAL_CORE" != "default" ]; then
     echo -e "web_environment:\n    - DRUPAL_CORE=^${TEST_DRUPAL_CORE}" > .ddev/config.~overrides.yaml
   fi
+  ddev add-on get ddev/ddev-selenium-standalone-chrome
   ddev add-on get ${DIR}
 }
 


### PR DESCRIPTION
to provide a full-flagged environment for running automated tests in contrib projects

## The Issue

-  Closes #124 