### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DDEV integration for developing Drupal contrib projects. As a general philosophy
 4. Configure DDEV for Drupal using `ddev config --project-type=drupal --docroot=web --php-version=8.3 --corepack-enable --project-name=[module]` or select these options when prompted using `ddev config`
    - Remove underscores in the project name, or replace with hyphens. (DDEV will do this for you.)
    - See [Misc](#misc) for help on using alternate versions of Drupal core.
-5. Run `ddev add-on get ddev/ddev-selenium-standalone-chrome ddev/ddev-drupal-contrib && ddev add-on get ddev/ddev-drupal-contrib`
+5. Run `ddev add-on get ddev/ddev-selenium-standalone-chrome && ddev add-on get ddev/ddev-drupal-contrib`
 6. Run `ddev start`
 7. Run `ddev poser`
 8. Run `ddev symlink-project`


### PR DESCRIPTION
## The Issue

I didn't create a separate issue, this is very small. I think the README instructions were incorrectly updated to install the selenium dependency. If you follow the existing instructions
```
$ ddev add-on get ddev/ddev-selenium-standalone-chrome ddev/ddev-drupal-contrib && ddev add-on get ddev/ddev-drupal-contrib
Error: accepts 1 arg(s), received 2
Usage:
  ddev add-on get <addonOrURL> [flags]
```

## How This PR Solves The Issue

## Manual Testing Instructions

Run the updated instructions.

```bash
ddev add-on get ddev/ddev-selenium-standalone-chrome && ddev add-on get ddev/ddev-drupal-contrib
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
