### PR TITLE
put back env vars

### DIFF
--- a/config.contrib.yaml
+++ b/config.contrib.yaml
@@ -10,6 +10,10 @@ web_environment:
   # To change the location of your project code, see the README:
   # https://github.com/ddev/ddev-drupal-contrib/blob/main/README.md#changing-the-symlink-location
   - DRUPAL_PROJECTS_PATH=modules/custom
+  - SIMPLETEST_DB=mysql://db:db@db/db
+  - SIMPLETEST_BASE_URL=http://web
+  - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
+  - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
 hooks:
   post-start:
     - exec-host: |


### PR DESCRIPTION
- **Add guidance about js dependencies**
- **Let DDEV determine a project name (#142)**
- **Restore env variables for when standalone-chrome is not in use.**

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
