### PR TITLE
Copying eslint's copying of core's .prettierrc.json to stylelint

### DIFF
--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -9,7 +9,10 @@
 
 set -eu -o pipefail
 
-if $DDEV_DOCROOT/core/node_modules/.bin/stylelint --version >/dev/null ; then
+if "$DDEV_DOCROOT/core/node_modules/.bin/stylelint" --version >/dev/null ; then
+  # Configure prettier
+  test -e .prettierrc.json || ln -s $DDEV_DOCROOT/core/.prettierrc.json .
+  test -e .prettierignore || echo '*.yml' > .prettierignore
   # Change directory to the project root folder
   cd "$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH/${DDEV_SITENAME//-/_}" || exit
   "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/stylelint" --color --config "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/.stylelintrc.json" "./**/*.css" "$@"


### PR DESCRIPTION
## The Issue
	•	[#3541738](https://www.drupal.org/project/gitlab_templates/issues/3541738)

Local stylelint differed from Gitlab CI because Gitlab CI links Core’s Prettier config; contrib projects didn’t.

How This PR Solves The Issue

- 	Mirrors the eslint wrapper: symlinks Core’s .prettierrc.json (and creates a minimal .prettierignore).
- 	Runs stylelint via Core’s binary with Core’s config (../../../core/.stylelintrc.json) to align local with CI.
- 	Intentional: copied from the existing eslint script for consistency.

## Manual Testing Instructions

# From the project directory:
Add a CSS file with newlines between selectors.
```
.some
  .really-super-califragilistic-long
  div#selector
  .chain
  .expialidocious {
  color: #ccc;
}
```
See that it doesn't balk at it, but does after.
```
ddev stylelint
```
## Automated Testing Overview

No new tests; change only affects local tooling. CI linting continues to validate behavior.

## Release/Deployment Notes

No runtime impact. If a project already has a local Prettier config, it remains in control; otherwise it inherits Core’s settings to match Gitlab CI.