### PR TITLE
Make default `PROJECT_FILES` respect `.gitattributes` `export-ignore`

### DIFF
--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -13,9 +13,53 @@ export _WEB_ROOT=$DDEV_DOCROOT
 cd "$DDEV_COMPOSER_ROOT" || exit
 curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/symlink_project.php
 
+# Suppress a warning from symlink_project.php about the list of project files
+# and folders being derived, because the environment variable PROJECT_FILES is
+# empty.
 if [ -z "${PROJECT_FILES-}" ]; then
-  # Suppress a warning.
-  PROJECT_FILES=$(ls -A --ignore="web" --ignore="vendor" --ignore="symlink_project.php" --ignore=".ddev" --ignore=".idea")
+  # Build the list of files to symlink by filtering out those excluded via
+  # .gitattributes export-ignore and a few common, hardcoded values.
+  FILTERED_PROJECT_FILES=()
+  EXPORT_IGNORE_PATTERNS=()
+  while IFS= read -r line; do
+    [[ "$line" =~ export-ignore ]] || continue
+    pattern=$(echo "$line" | sed 's/#.*//' | awk '{print $1}')
+    [[ -z "$pattern" ]] && continue
+    # Normalize pattern: remove leading slash, handle trailing slash for directories
+    pat="$pattern"
+    pat="${pat#/}"
+    # Convert trailing slash to glob for directories
+    [[ "$pat" == */ ]] && pat="${pat%/}/*"
+    EXPORT_IGNORE_PATTERNS+=("$pat")
+  done < "$DDEV_COMPOSER_ROOT/.gitattributes"
+
+  for f in * .*; do
+    [[ "$f" == .* ]] && continue
+    case "$f" in
+      web|docroot|vendor|symlink_project.php|.ddev|.idea) continue ;;
+    esac
+    skip=false
+    for pat in "${EXPORT_IGNORE_PATTERNS[@]}"; do
+      # Match top-level file or directory
+      if [[ "$f" == $pat ]]; then
+        skip=true
+        break
+      fi
+      # Match directory pattern (e.g., build/ matches build and build/*)
+      if [[ "$pat" == */* ]] && [[ -d "$f" ]] && [[ "$f" == "${pat%%/*}" ]]; then
+        skip=true
+        break
+      fi
+      # Match file extension pattern (e.g., *.scss)
+      if [[ "$pat" == *.* ]] && [[ "$f" == $pat ]]; then
+        skip=true
+        break
+      fi
+    done
+    $skip && continue
+    FILTERED_PROJECT_FILES+=("$f")
+  done
+  PROJECT_FILES="$(printf '%s\n' "${FILTERED_PROJECT_FILES[@]}")"
   export PROJECT_FILES
 fi
 


### PR DESCRIPTION
<!--
I'm reckless, and I'm not creating an issue first! :shocked face:

## The Issue

- #<issue number>
-->

The `symlink-project` command helpfully provides a way to override the list of files it should symlink via the `PROJECT_FILES` environment variable. This is great if you're willing to hardcode the list, but more than a little difficult to achieve if you want a dynamic list. In order to get the most production-like version of my module placed, I wanted to *not* symlink any files that would be omitted by the Drupal.org Composer Facade, i.e., those that aren't excluded via `.gitattributes` `export-ignore`. (At first I wanted to exclude those in `.gitignore`, too, but then I realized that could incorrectly exclude compiled code, like CSS and JS.) And I didn't want to hardcode that list and set future developers up for failure when they add new files and forget about it.

So I came up with a solution. It works for me, and I'm satisfied with it. I don't know if it will interest anyone else, but I thought I'd put it out there in case it could help someone. I don't necessarily expect that it will actually be merged.

## How This PR Solves The Issue

It makes the default behavior in `symlink-project` exclude not only the hardcoded list of common files but also any that are in `.gitattributes` with `export-ignore`. (I also added "docroot" to the default list while I was there, since some hosting providers (e.g., Acquia) use that.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/TravisCarden/ddev-drupal-contrib/tarball/feature/dynamic-project-files
ddev restart

# Add a file:
touch test.txt

# See that symlink-project symlinks it. (Expect output "test.txt")
ddev symlink-project 2>/dev/null | grep test.txt

# Add it to .gitattributes:
echo '/test.txt  export-ignore' | tee -a .gitattributes

# See that symlink-project does NOT symlinks it. (Expect no output.)
ddev symlink-project | grep test.txt
```

## Automated Testing Overview

As I'm just "throwing this over the wall", I'm not taking the time to write automated tests.

## Release/Deployment Notes

TBD