### PR TITLE
fix: ignore .ddev directory in phpcbf execution

### DIFF
--- a/commands/web/phpcbf
+++ b/commands/web/phpcbf
@@ -14,4 +14,4 @@ if ! command -v phpcbf >/dev/null; then
   exit 1
 fi
 test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpcs.xml.dist
-phpcbf -s --report-full --report-summary --report-source $DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH "$@"
+phpcbf -s --report-full --report-summary --report-source $DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH --ignore=*/.ddev/* "$@"


### PR DESCRIPTION
Add ignore option for .ddev directory in phpcbf command same as phpcs

