### PR TITLE
Fix #177: ensure symlink-project adds /vendor/ and /web/ to gitignore

### DIFF
--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -25,3 +25,11 @@ fi
 export DRUPAL_PROJECT_FOLDER=${DDEV_DOCROOT}/${DRUPAL_PROJECTS_PATH}/${DDEV_SITENAME//-/_}
 php symlink_project.php
 rm -f symlink_project.php
+
+# Ensure generated Drupal scaffold paths are ignored in contrib repositories.
+touch .gitignore
+for pattern in "/vendor/" "/web/"; do
+  if ! grep -Fxq "$pattern" .gitignore; then
+    printf "%s\n" "$pattern" >> .gitignore
+  fi
+done

--- a/tests/full.bats
+++ b/tests/full.bats
@@ -30,6 +30,16 @@ teardown_file() {
   ls -la web/modules/custom/test_drupal_contrib/test_drupal_contrib.info.yml
 }
 
+@test "ddev symlink-project updates gitignore" {
+  touch .gitignore
+  run -0 ddev symlink-project
+  run -0 ddev symlink-project
+  run -0 grep -Fx "/vendor/" .gitignore
+  run -0 grep -Fx "/web/" .gitignore
+  run -0 sh -c '[ "$(grep -c -Fx "/vendor/" .gitignore)" -eq 1 ]'
+  run -0 sh -c '[ "$(grep -c -Fx "/web/" .gitignore)" -eq 1 ]'
+}
+
 @test "php tools availability" {
   ddev phpcs --version
   ddev phpstan --version


### PR DESCRIPTION
## The Issue

- #177

After running the documented Drupal contrib setup flow, `.gitignore` is not updated automatically with `/vendor/` and `/web/`, which can lead to accidental commits of generated scaffold directories.

## How This PR Solves The Issue

- Updates `ddev symlink-project` to ensure `.gitignore` contains:
  - `/vendor/`
  - `/web/`
- Keeps the behavior idempotent by appending each entry only when it is missing.
- Preserves existing `.gitignore` content.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tormi/ddev-drupal-contrib/tarball/GH-177
ddev restart
```

Then verify:
- Run `ddev symlink-project`
- Confirm `.gitignore` includes `/vendor/` and `/web/`
- Run `ddev symlink-project` again and confirm no duplicate entries are added

## Automated Testing Overview

- Added a Bats test in `tests/full.bats`:
  - `@test "ddev symlink-project updates gitignore"`
- The test validates both entries are present and confirms idempotency (single occurrence after repeated runs).
- In this local session, full Bats execution was not completed because `./tests/bats/bin/bats` was not available until submodules are initialized.

## Release/Deployment Notes

- No deployment changes required.
- Change is limited to add-on command behavior and test coverage.
- Backward compatible and safe for existing projects because updates are append-only when entries are absent.
