### PR TITLE
Do not symlink .claude into the project directory

### DIFF
--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -15,7 +15,7 @@ curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/s
 
 if [ -z "${PROJECT_FILES-}" ]; then
   # Suppress a warning.
-  PROJECT_FILES=$(ls -A --ignore="web" --ignore="vendor" --ignore="symlink_project.php" --ignore=".ddev" --ignore=".idea")
+  PROJECT_FILES=$(ls -A --ignore="web" --ignore="vendor" --ignore="symlink_project.php" --ignore=".ddev" --ignore=".idea" --ignore=".claude")
   export PROJECT_FILES
 fi
 


### PR DESCRIPTION
### The problem

`symlink-project` links every top-level entry into `web/modules/custom/<project>/` except `web`, `vendor`, `symlink_project.php`, `.ddev` and `.idea`:

https://github.com/ddev/ddev-drupal-contrib/blob/main/commands/web/symlink-project#L18

Claude Code stores its state in `.claude/`, and that includes git worktrees under `.claude/worktrees/` — each one a full checkout of the project, with its own `vendor/`. So `.claude` gets symlinked in, and anything pointed at `web/modules/custom/<project>` walks all of it.

On one Drupal module I measured:

| Entry in the symlinked tree | `.php` files |
| --- | --- |
| `.claude` | 20,047 |
| `tests` | 76 |
| `src` | 30 |
| everything else | 2 |

`.claude` was ~300 MB.

The first symptom was `ddev phpcs` dying with exit 137 (OOM-killed) instead of reporting anything — it passes `$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH` as a path argument, which overrides the `<file>` list in the project's `phpcs.xml.dist`. That reads as a broken tool rather than as a tree that should never have been in scope, and it took a while to trace back to here. `ddev phpstan` and `ddev phpunit` are unaffected, since both are scoped by their own config rather than by that path.

This is only going to get more common as more Drupal contributors run Claude Code.

### The change

One more `--ignore`. `.claude` belongs in the same category as `.idea`: a tool's own directory that happens to sit in the project root and is not part of the project.

### Verification

Applied to a real module's copy of the command and re-ran `ddev symlink-project`:

- `.claude` no longer appears in `web/modules/custom/<project>/`
- every module file is still linked (`src`, `config`, `tests`, `*.info.yml`, …)
- `find -L web/modules/custom -name '*.php' | wc -l` drops from **20,394** to **108**
- `ddev phpcs` completes in ~2s over 34 files instead of being killed

### Possibly worth a follow-up

`.vscode` is a comparable gap next to `.idea`, though it is small and carries no PHP, so it causes nothing like this. I left it out to keep the change to the actual bug.
